### PR TITLE
Swap result type parameters for note/hush

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-abstract",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/implementations/Result.re
+++ b/src/implementations/Result.re
@@ -449,7 +449,7 @@ module Unsafe = {
 
 let is_ok = a => result(const(true), const(false), a)
 and is_error = a => result(const(false), const(true), a)
-and note: ('a, option('b)) => Belt.Result.t('a, 'b) =
+and note: ('err, option('a)) => Belt.Result.t('a, 'err) =
   default => Option.maybe(~f=x => Ok(x), ~default=Error(default))
-and hush: Belt.Result.t('a, 'b) => option('b) =
+and hush: Belt.Result.t('a, 'err) => option('a) =
   e => result(Option.Applicative.pure, const(None), e);

--- a/test/Test_Result.re
+++ b/test/Test_Result.re
@@ -695,4 +695,30 @@ describe("Result", () => {
       V.excluded_middle,
     );
   });
+
+  describe("Result_Utilities", () => {
+    let errResult: Belt.Result.t(int, string) = Belt.Result.Error("ERROR");
+    let okResult: Belt.Result.t(int, string) = Belt.Result.Ok(4);
+    let someFloat = Some(5.0);
+
+    describe("Hush", () => {
+      it("should convert Error result to None", () => {
+        expect(Result.hush(errResult)) |> to_be(None);
+      });
+
+      it("should convert Success result to Some", () => {
+        expect(Result.hush(okResult)) |> to_be(Some(4));
+      });
+    });
+
+    describe("Note", () => {
+      it("should convert None to Error result", () => {
+        expect(Result.note("ERROR", None)) |> to_be(Belt.Result.Error("ERROR"));
+      });
+
+      it("should convert Some to Ok result", () => {
+        expect(Result.note("ERROR", someFloat)) |> to_be(Belt.Result.Ok(5.0));
+      });
+    });
+  });
 });


### PR DESCRIPTION
`Belt.Result.t` puts the success type parameter on the left, and the error on the right (...go figure). These were switched in `Result.note` and `Result.hush`, which led to confusing results when using these functions with `Belt.Result.t('a, 'a)` and the inability to compile with `Belt.Result.t('a, 'b)` where `'a` and `'b` are different types.

I added a few tests to demonstrate this, and  switched the type parameters in those two functions.