### PR TITLE
Bugfix/applicative both

### DIFF
--- a/src/functions/Functions.re
+++ b/src/functions/Functions.re
@@ -43,6 +43,8 @@ module Apply = (A: APPLY) => {
     (a, b) => const <$> a <*> b
   and apply_second: (A.t('a), A.t('b)) => A.t('b) =
     (a, b) => const(id) <$> a <*> b
+  and apply_both: (A.t('a), A.t('b)) => A.t(('a, 'b)) =
+    (a, b) => ((a', b') => (a', b')) <$> a <*> b
   and lift2: (('a, 'b) => 'c, A.t('a), A.t('b)) => A.t('c) =
     (f, a, b) => f <$> a <*> b
   and lift3: (('a, 'b, 'c) => 'd, A.t('a), A.t('b), A.t('c)) => A.t('d) =
@@ -84,11 +86,13 @@ module Apply' = (A: APPLY, T: TYPE) => {
   let apply_const: (A.t(T.t) => A.t('a), A.t(T.t)) => A.t(T.t) =
     (f, x) => F'.apply(Apply_A.apply_first, f, x);
 
-  /* Like Apply.apply_(first|second) but takes functions in the form of `T.t => A.t('a)` */
+  /* Like Apply.apply_(first|second|both) but takes functions in the form of `T.t => A.t('a)` */
   let apply_first: (T.t => A.t('a), T.t => A.t('b), T.t) => A.t('a) =
     (f, g, x) => Apply_F.lift2(Apply_A.apply_first, f, g, x)
   and apply_second: (T.t => A.t('a), T.t => A.t('b), T.t) => A.t('b) =
-    (f, g, x) => Apply_F.lift2(Apply_A.apply_second, f, g, x);
+    (f, g, x) => Apply_F.lift2(Apply_A.apply_second, f, g, x)
+  and apply_both: (T.t => A.t('a), T.t => A.t('b), T.t) => A.t(('a, 'b)) =
+    (f, g, x) => Apply_F.lift2(Apply_A.apply_both, f, g, x);
 };
 
 module Applicative = (A: APPLICATIVE) => {
@@ -98,7 +102,7 @@ module Applicative = (A: APPLICATIVE) => {
     (f, fa) => I.(A.pure(f) <*> fa)
   and when_: (bool, A.t(unit)) => A.t(unit) = (p, fa) => p ? fa : A.pure()
   and unless: (bool, A.t(unit)) => A.t(unit) =
-    (p, fa) => ! p ? fa : A.pure();
+    (p, fa) => !p ? fa : A.pure();
 };
 
 module Monad = (M: MONAD) => {

--- a/src/interfaces/PPX_Let.re
+++ b/src/interfaces/PPX_Let.re
@@ -13,14 +13,15 @@ module type PPX_LET = {
 
 /* Makes the `ppx_let` module from a monad */
 module Make = (M: MONAD) => {
+  module A = Functions.Apply(M);
+
   module Let_syntax: PPX_LET with type t('a) = M.t('a) = {
     type t('a) = M.t('a);
 
     let return = M.pure
     and bind = M.flat_map
     and map = (a, ~f) => M.map(f, a)
-    and both = (a, b) =>
-      M.flat_map(a, a' => M.flat_map(b, b' => M.pure((a', b'))));
+    and both = A.apply_both;
 
     module Open_on_rhs = {
       let return = M.pure;

--- a/test/Test_PPX_Let.re
+++ b/test/Test_PPX_Let.re
@@ -1,0 +1,59 @@
+open BsMocha.Mocha;
+open! BsMocha.Async;
+open BsChai.Expect.Expect;
+open BsChai.Expect.Combos.End;
+let (<.) = Function.Infix.(<.);
+
+[@bs.module "perf_hooks"] [@bs.scope "performance"]
+external now: unit => float = "";
+
+describe("PPX_Let", () => {
+  module Monad: Interface.MONAD with type t('a) = ('a => unit) => unit = {
+    type t('a) = ('a => unit) => unit;
+    let map = (f, ta, cb) => ta(cb <. f);
+    let apply = (tf, ta, cb) => {
+      let state = ref(`None);
+      tf(f =>
+        switch (state^) {
+        | `Some_A(a) => cb(f(a))
+        | _ => state := `Some_F(f)
+        }
+      );
+      ta(a =>
+        switch (state^) {
+        | `Some_F(f) => cb(f(a))
+        | _ => state := `Some_A(a)
+        }
+      );
+    };
+    let pure = (a, cb) => cb(a);
+    let flat_map = (ta, f, cb) => ta(a => f(a, cb));
+  };
+  module PPX_Let = PPX_Let.Make(Monad);
+  open PPX_Let.Let_syntax;
+
+  let delayed_cb = (delay, cb) =>
+    Js.Global.setTimeout(cb <. now, delay) |> ignore;
+  let fast_cb = delayed_cb(100);
+  let slow_cb = delayed_cb(200);
+  let expect_first = (matcher, (a, b)) => expect(a) |> matcher(b);
+
+  describe("bind", () => {
+    let bind_both = (ta, tb) => bind(ta, a => bind(tb, b => return((a, b))));
+    it("should resolve first callback first when it resolves faster", done_ =>
+      bind_both(fast_cb, slow_cb, done_ <. expect_first(to_be_below))
+    );
+    it("should resolve first callback first when it resolves slower", done_ =>
+      bind_both(slow_cb, fast_cb, done_ <. expect_first(to_be_below))
+    );
+  });
+
+  describe("both", () => {
+    it("should resolve first callback first when it resolves faster", done_ =>
+      both(fast_cb, slow_cb, done_ <. expect_first(to_be_below))
+    );
+    it("should resolve first callback second when it resolves slower", done_ =>
+      both(slow_cb, fast_cb, done_ <. expect_first(to_be_above))
+    );
+  });
+});


### PR DESCRIPTION
`both` in `ppx_let` is for concurrency but the current implementation forces sequential execution.

### Test

A concurrent applicative needs lazy evaluation. Since OCaml is strict the monad's type is a simple callback to the underlying type. The methods are straightforward except `apply` which awaits both callbacks concurrently. If its state is empty it stores the underlying value otherwise it applies both for the listener. The `bind` tests expect callbacks to execute sequentially while the `both` tests verify concurrency.

### Implementation

Adds `apply_both` to the `Apply` type class. It seemed perfect because of its symmetry to `apply_first`. Formally `both` is the `Monoidal` equivalent of `apply`. I thought `both` would need `pure` for lifted `map` but it worked without it. I also considered supplying overrides but it's tricky to implement lawfully.