### PR TITLE
Add semigroup and monoid to list and array

### DIFF
--- a/src/implementations/Array.re
+++ b/src/implementations/Array.re
@@ -15,6 +15,20 @@ let zip_with: (('a, 'b) => 'c, array('a), array('b)) => array('c) =
 let zip: (array('a), array('b)) => array('c) =
   (xs, ys) => zip_with((a, b) => (a, b), xs, ys);
 
+module Magma_Any: MAGMA_ANY with type t('a) = array('a) = {
+  type t('a) = array('a);
+  let append = ArrayLabels.append;
+};
+
+module Semigroup_Any: SEMIGROUP_ANY with type t('a) = array('a) = {
+  include Magma_Any;
+};
+
+module Monoid_Any: MONOID_ANY with type t('a) = array('a) = {
+  include Semigroup_Any;
+  let empty = [||];
+};
+
 module type EQ_F = (E: EQ) => EQ with type t = array(E.t);
 module type ORD_F = (O: ORD) => ORD with type t = array(O.t);
 module type SHOW_F = (S: SHOW) => SHOW with type t = array(S.t);

--- a/src/implementations/List.re
+++ b/src/implementations/List.re
@@ -1,5 +1,19 @@
 open Interface;
 
+module Magma_Any: MAGMA_ANY with type t('a) = list('a) = {
+  type t('a) = list('a);
+  let append = ListLabels.append;
+};
+
+module Semigroup_Any: SEMIGROUP_ANY with type t('a) = list('a) = {
+  include Magma_Any;
+};
+
+module Monoid_Any: MONOID_ANY with type t('a) = list('a) = {
+  include Semigroup_Any;
+  let empty = [];
+};
+
 module type EQ_F = (E: EQ) => EQ with type t = list(E.t);
 module type SHOW_F = (S: SHOW) => SHOW with type t = list(S.t);
 module type TRAVERSABLE_F =

--- a/test/Test_Array.re
+++ b/test/Test_Array.re
@@ -35,6 +35,22 @@ describe("Array", () => {
     );
   });
 
+  describe("Semigroup_Any", () => {
+    module V = Verify.Semigroup_Any(Array.Semigroup_Any);
+    property3(
+      "should satisfy associativity",
+      arb_array(arb_nat),
+      arb_array(arb_nat),
+      arb_array(arb_nat),
+      V.associativity,
+    );
+  });
+
+  describe("Monoid_Any", () => {
+    module V = Verify.Monoid_Any(Array.Monoid_Any);
+    property1("should satisfy identity", arb_array(arb_nat), V.identity);
+  });
+
   describe("Functor", () => {
     module V = Verify.Functor(Array.Functor);
     property1("should satisfy identity", arb_array(arb_nat), V.identity);

--- a/test/Test_List.re
+++ b/test/Test_List.re
@@ -7,6 +7,22 @@ open Functors;
 let (<.) = Function.Infix.(<.);
 
 describe("List", () => {
+  describe("Semigroup_Any", () => {
+    module V = Verify.Semigroup_Any(List.Semigroup_Any);
+    property3(
+      "should satisfy associativity",
+      arb_list(arb_nat),
+      arb_list(arb_nat),
+      arb_list(arb_nat),
+      V.associativity,
+    );
+  });
+
+  describe("Monoid_Any", () => {
+    module V = Verify.Monoid_Any(List.Monoid_Any);
+    property1("should satisfy identity", arb_list(arb_nat), V.identity);
+  });
+
   describe("Functor", () => {
     module V = Verify.Functor(List.Functor);
     property1("should satisfy identity", arb_list(arb_nat), V.identity);


### PR DESCRIPTION
The implementation modules for `List` and `Array` don't include implementations for `SEMIGROUP_ANY` and `MAGMA_ANY`, so I added them. If their omission was intentional, feel free to close this PR.

In the process, I also noticed that the `associativity` check in `Verify.Semigroup_Any` doesn't seem to have a problem with the following definitions of `append`:
  - `(_, _) => []`
  - `(a, _) => a`
  - `(_, b) => b`

I tried changing the `associativity` function in `Verify` from:

```
I.(E.eq(a <:> (b <:> c), a <:> (b <:> c)))
```

to

```
I.(E.eq((a <:> b) <:> c, a <:> (b <:> c)))
```

...but that didn't seem to make a difference (tests still passed, even though it seems like they shouldn't). The `identity` check from `Verify.Monoid_Any` _does_ fail when I use those bad definitions of `append`, but I would expect the `associativity` test to fail as well.