### PR TITLE
Flip order of Array.Alt.alt concatenation

### DIFF
--- a/src/implementations/Array.re
+++ b/src/implementations/Array.re
@@ -55,7 +55,7 @@ module Monad: MONAD with type t('a) = array('a) = {
 
 module Alt: ALT with type t('a) = array('a) = {
   include Functor;
-  let alt = Js.Array.concat;
+  let alt = (a, b) => Js.Array.concat(b, a);
 };
 
 module Plus: PLUS with type t('a) = array('a) = {


### PR DESCRIPTION
This is the small version of the fix to #9 which makes `Array.Alt.alt` consistent with `List.Alt.alt` (as well as PureScript's `alt` implementation for Array, etc).

There are no unit-style tests for this, but the associativity and distributivity checks for Array.Alt still hold.