### PR TITLE
Unfoldable

### DIFF
--- a/src/implementations/Array.re
+++ b/src/implementations/Array.re
@@ -115,7 +115,7 @@ module Unfoldable: UNFOLDABLE with type t('a) = array('a) = {
   let rec unfold = (f, init) =>
     switch(f(init)) {
       | Some((a, next)) =>
-       Js.Array.concat(unfold(f, next), [|a|])
+       Belt.Array.concat([|a|], unfold(f, next))
       | None => [||]
     };
 };

--- a/src/implementations/Array.re
+++ b/src/implementations/Array.re
@@ -109,6 +109,17 @@ module Foldable: FOLDABLE with type t('a) = array('a) = {
   };
 };
 
+module Unfoldable: UNFOLDABLE with type t('a) = array('a) = {
+  type t('a) = array('a);
+
+  let rec unfold = (f, init) =>
+    switch(f(init)) {
+      | Some((a, next)) =>
+       Js.Array.concat(unfold(f, next), [|a|])
+      | None => [||]
+    };
+};
+
 module Traversable: TRAVERSABLE_F =
   (A: APPLICATIVE) => {
     type t('a) = array('a)

--- a/src/implementations/List.re
+++ b/src/implementations/List.re
@@ -93,6 +93,16 @@ module Foldable: FOLDABLE with type t('a) = list('a) = {
   };
 };
 
+module Unfoldable: UNFOLDABLE with type t('a) = list('a) = {
+  type t('a) = list('a);
+
+  let rec unfold = (f, init) =>
+    switch(f(init)) {
+      | Some((a, next)) => [a, ...unfold(f, next)]
+      | None =>  []
+    };
+};
+
 module Traversable: TRAVERSABLE_F =
   (A: APPLICATIVE) => {
     type t('a) = list('a)

--- a/src/interfaces/Interface.re
+++ b/src/interfaces/Interface.re
@@ -100,6 +100,12 @@ module type FOLDABLE = {
     (P: PLUS) => {let fold_map: ('a => P.t('a), t('a)) => P.t('a);};
 };
 
+module type UNFOLDABLE = {
+  type t('a);
+
+  let unfold: ('a => option(('a, 'a))) => 'a => t('a);
+};
+
 module type TRAVERSABLE = {
   include FUNCTOR;
   include FOLDABLE with type t('a) := t('a);

--- a/test/Test_Array.re
+++ b/test/Test_Array.re
@@ -141,6 +141,14 @@ describe("Array", () => {
     });
   });
 
+  describe("Unfoldable", () => {
+    open Array.Unfoldable;
+    it("should do unfold", () => {
+      expect(unfold(x => if (x>5) None else Some((x, x+1)), 0)) |> to_be([|0, 1, 2, 3, 4, 5|]);
+      expect(unfold(x => if (x>20) None else Some((x, x+5)), 0)) |> to_be([|0, 5, 10, 15, 20|]);
+    });
+  });
+
   describe("Traversable", () => {
     let (traverse, sequence) =
       ArrayF.Option.Traversable.(traverse, sequence);

--- a/test/Test_List.re
+++ b/test/Test_List.re
@@ -116,6 +116,14 @@ describe("List", () => {
     });
   });
 
+  describe("Unfoldable", () => {
+    open List.Unfoldable;
+    it("should do unfold", () => {
+      expect(unfold(x => if (x>5) None else Some((x, x+1)), 0)) |> to_be([0, 1, 2, 3, 4, 5]);
+      expect(unfold(x => if (x>20) None else Some((x, x+5)), 0)) |> to_be([0, 5, 10, 15, 20]);
+    });
+  });
+
   describe("Traversable", () => {
     module T = List.Traversable(Option.Applicative);
 


### PR DESCRIPTION
`UNFOLDABLE` interface with `List` and `Array` implementation.

I used `Js.Array.concat` for the array implementation, but if you're really keen on performance, I'll switch it to use an explicit loop to build the array. Actually, the `Belt` library already uses optimized stuff like that for their `concat`, but not sure how you feel about using `Belt` in this library.