### PR TITLE
Allow options to be compared for ordering

### DIFF
--- a/src/implementations/Option.re
+++ b/src/implementations/Option.re
@@ -17,6 +17,7 @@ module type QUASIGROUP_F =
   (Q: QUASIGROUP) => QUASIGROUP with type t = option(Q.t);
 module type LOOP_F = (L: LOOP) => LOOP with type t = option(L.t);
 module type EQ_F = (E: EQ) => EQ with type t = option(E.t);
+module type ORD_F = (O: ORD) => ORD with type t = option(O.t);
 module type SHOW_F = (S: SHOW) => SHOW with type t = option(S.t);
 module type TRAVERSABLE_F =
   (A: APPLICATIVE) =>
@@ -146,6 +147,18 @@ module Eq: EQ_F =
       | (Some(a), Some(b)) => E.eq(a, b)
       | (None, None) => true
       | _ => false
+      };
+  };
+
+module Ord: ORD_F =
+  (O: ORD) => {
+    include Eq(O);
+    let compare = (a, b) =>
+      switch (a, b) {
+      | (Some(a'), Some(b')) => O.compare(a', b')
+      | (None, None) => `equal_to
+      | (None, Some(_)) => `less_than
+      | (Some(_), None) => `greater_than
       };
   };
 

--- a/src/utilities/Functors.re
+++ b/src/utilities/Functors.re
@@ -134,6 +134,7 @@ module ListF = {
 module OptionF = {
   module Int = {
     module Eq = Option.Eq(Int.Eq);
+    module Ord = Option.Ord(Int.Ord);
     module Additive = {
       module Semigroup = Option.Semigroup(Int.Additive.Semigroup);
       module Quasigroup = Option.Quasigroup(Int.Additive.Quasigroup);
@@ -152,6 +153,7 @@ module OptionF = {
   };
   module Float = {
     module Eq = Option.Eq(Float.Eq);
+    module Ord = Option.Ord(Float.Ord);
     module Additive = {
       module Semigroup = Option.Semigroup(Float.Additive.Semigroup);
       module Quasigroup = Option.Quasigroup(Float.Additive.Quasigroup);
@@ -173,6 +175,7 @@ module OptionF = {
   };
   module Bool = {
     module Eq = Option.Eq(Bool.Eq);
+    module Ord = Option.Ord(Bool.Ord);
     module Conjunctive = {
       module Semigroup = Option.Semigroup(Bool.Conjunctive.Semigroup);
       module Monoid = Option.Monoid(Bool.Conjunctive.Semigroup);
@@ -184,6 +187,7 @@ module OptionF = {
   };
   module String = {
     module Eq = Option.Eq(String.Eq);
+    module Ord = Option.Ord(String.Ord);
     module Semigroup = Option.Semigroup(String.Semigroup);
     module Monoid = Option.Monoid(String.Semigroup);
   };

--- a/test/Test_Option.re
+++ b/test/Test_Option.re
@@ -172,4 +172,16 @@ describe("Option", () => {
       V.transitivity,
     );
   });
+
+  describe("Ord", () =>
+    it("should compare two option values for equality", () => {
+      let compare = Functors.OptionF.Float.Ord.compare;
+      expect(compare(Some(1.23), Some(1.23))) |> to_be(`equal_to);
+      expect(compare(Some(1.23), Some(4.56))) |> to_be(`less_than);
+      expect(compare(Some(1.23), Some(-1.23))) |> to_be(`greater_than);
+      expect(compare(None, None)) |> to_be(`equal_to);
+      expect(compare(None, Some(-1.23))) |> to_be(`less_than);
+      expect(compare(Some(0.0), None)) |> to_be(`greater_than);
+    })
+  );
 });


### PR DESCRIPTION
This adds the `ORD_F` functor to `Option`, allowing options to be compared if the inner type is a member of `ORD`. I also added non-functor specializations in `OptionF` wherever `Eq` existed (e.g. `OptionF.Int.Ord`).