### PR TITLE
Allow fold_map to map underlying type for Any/Plus

### DIFF
--- a/src/interfaces/Interface.re
+++ b/src/interfaces/Interface.re
@@ -95,9 +95,9 @@ module type FOLDABLE = {
 
   module Fold_Map: (M: MONOID) => {let fold_map: ('a => M.t, t('a)) => M.t;};
   module Fold_Map_Any:
-    (M: MONOID_ANY) => {let fold_map: ('a => M.t('a), t('a)) => M.t('a);};
+    (M: MONOID_ANY) => {let fold_map: ('a => M.t('b), t('a)) => M.t('b);};
   module Fold_Map_Plus:
-    (P: PLUS) => {let fold_map: ('a => P.t('a), t('a)) => P.t('a);};
+    (P: PLUS) => {let fold_map: ('a => P.t('b), t('a)) => P.t('b);};
 };
 
 module type UNFOLDABLE = {

--- a/test/Test_List.re
+++ b/test/Test_List.re
@@ -114,6 +114,12 @@ describe("List", () => {
       expect(fold_map(List.Applicative.pure, [[1, 2, 3], [4, 5]]))
       |> to_be([[1, 2, 3], [4, 5]]);
     });
+
+    it("should do a map fold ('a => array('b))", () => {
+      let fold_map = ListF.Array.Fold_Map_Plus.fold_map;
+      expect(fold_map(Array.Applicative.pure <. Int.Show.show, [1, 2, 3]))
+      |> to_be([|"1", "2", "3"|])
+    });
   });
 
   describe("Unfoldable", () => {


### PR DESCRIPTION
When doing a `fold_map` where the monoid has its own type parameter (e.g. `MONOID_ANY` or `PLUS`), the "map" part should be able to convert the `'a` into any `M.t('b)`; it shouldn't be required to keep the `'a` part the same while mapping.

For example, in PureScript:

```purescript
f :: List Int -> Array String
f xs = foldMap (pure <<< show) xs
```

Previously, the Reason equivalent of this function failed to compile, but it should be working now (with a new test confirming it).

```reason
// previously this example failed to compile, but it does now
let fold_map = ListF.Array.Fold_Map_Plus.fold_map;
let f: list(int) => array(string) = xs =>
  fold_map(Array.Applicative.pure <. Int.Show.show, xs);
```

There might be a similar change needed in `BIFOLDABLE`, but I'm not completely sure.