### PR TITLE
Remove the patch number from dune lang version

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.0.1)
+(lang dune 2.0)
 (name bastet)
 (source (github Risto-Stevcev/bastet))
 (license BSD-3-Clause)


### PR DESCRIPTION
This part of the version number is ignored by dune and results in a
warning 'The ".1" part is ignored here'
